### PR TITLE
fix: set prefix for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Europe/Vienna"
+    commit-message:
+      prefix: chore
 
   - package-ecosystem: "nuget"
     directory: "/"
@@ -15,6 +17,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Europe/Vienna"
+    commit-message:
+      prefix: chore
     groups:
       nuke:
         patterns:


### PR DESCRIPTION
Set the [prefix](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#prefix) to `chore` for dependabot PRs.