### PR TITLE
docs: add template for documentation

### DIFF
--- a/.idea/.idea.aweXpect.T6e/.idea/indexLayout.xml
+++ b/.idea/.idea.aweXpect.T6e/.idea/indexLayout.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="UserContentModel">
-    <attachedFolders />
+    <attachedFolders>
+      <Path>Docs</Path>
+    </attachedFolders>
     <explicitIncludes />
     <explicitExcludes />
   </component>

--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -1,0 +1,5 @@
+﻿# [aweXpect.T6e](https://github.com/aweXpect/aweXpect.T6e) [![Nuget](https://img.shields.io/nuget/v/aweXpect.T6e)](https://www.nuget.org/packages/aweXpect.T6e)
+
+Template for extension projects for [aweXpect](https://github.com/aweXpect/aweXpect).
+
+{README}


### PR DESCRIPTION
This PR adds a documentation template file to establish the structure for project documentation. The template includes a basic header with project branding and a placeholder for README content that is automatically applied in the [aweXpect Build.Pages](https://github.com/aweXpect/aweXpect/blob/main/Pipeline/Build.Pages.cs) step.